### PR TITLE
Add results list to pages

### DIFF
--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -1,5 +1,6 @@
 @import "node_modules/lbh-frontend/lbh/core/all";
 @import "node_modules/lbh-frontend/lbh/objects/all";
+@import "node_modules/lbh-frontend/lbh/overrides/all";
 @import "node_modules/lbh-frontend/lbh/helpers/colour";
 @import "node_modules/lbh-frontend/lbh/components/lbh-accordion/accordion";
 @import "node_modules/lbh-frontend/lbh/components/lbh-back-link/back-link";
@@ -24,13 +25,6 @@
 
 html.lbh-template > body.lbh-template__body * {
   font-family: 'Open Sans', sans-serif;
-}
-#address-lookup-fieldset {
-  display: none;
-
-  .js-enabled & {
-    display: block;
-  }
 }
 
 .note-container {
@@ -117,12 +111,6 @@ html.lbh-template > body.lbh-template__body * {
   }
 }
 
-#what_coronavirus_help,
-#current_support {
-  @include govuk-media-query($from: tablet) {
-    column-count: 2;
-  }
-}
 
 .text-align-right {
   text-align: right;

--- a/views/index.njk
+++ b/views/index.njk
@@ -1,12 +1,14 @@
 {% from 'lbh-input/macro.njk' import lbhInput %}
 {% from 'lbh-fieldset/macro.njk' import lbhFieldset %}
+{% from 'partials/userNav.njk' import UserNav %}
 
 {% extends "./layouts/base.njk" %}
 
 {% block content %}
-
+  
+  {{ UserNav({userName: "Jayson Hunter"}) }}
   <h1 class="lbh-heading-h1">Interim Social Care Admin</h1>
-
+  
   <table class="govuk-table lbh-table">
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">

--- a/views/layouts/base.njk
+++ b/views/layouts/base.njk
@@ -15,9 +15,6 @@
    <link rel="stylesheet" type="text/css" href="/app.css">
 {% endblock %}
 
-
-{% block pageTitle %}Interim Social Care Admin | Hackney Council{% endblock %}
-
 {% block header %}
   {{lbhHeader({
     isHome: false,
@@ -25,10 +22,12 @@
   })}}
 {% endblock %}
 
+{% block pageTitle %}Interim Social Care Admin | Hackney Council{% endblock %}
+
 {% block beforeContent %}
-<div id="loader_overlay" class="">
-  <div id="loader_spinner"></div>
-</div>
+  <div id="loader_overlay" class="">
+    <div id="loader_spinner"></div>
+  </div>
 {% endblock %}
 
 {% block bodyEnd %}

--- a/views/partials/userNav.njk
+++ b/views/partials/userNav.njk
@@ -1,0 +1,11 @@
+{% macro UserNav(data) %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <p class="lbh-body-s text-align-right">
+            <span class="lbh-!-font-weight-bold">Logged in as: </span>
+            {{data.userName}}
+            <a href="/logout" class="lbh-link">Logout</a>
+        </p>
+    </div>
+</div>
+{% endmacro %}

--- a/views/socialcare/my-records-list.njk
+++ b/views/socialcare/my-records-list.njk
@@ -2,8 +2,6 @@
 {% from 'lbh-radios/macro.njk' import lbhRadios %}
 {% from "lbh-back-link/macro.njk" import lbhBackLink %}
 
-{# Import records list partial here #}
-
 {% extends "../layouts/base.njk" %}
 
 {% block content %}
@@ -14,11 +12,43 @@
     }) }}
 
     {% if data | length %}
-        <h2 class="lbh-heading-h2">Records created by : {{data}}</h2>
+        <h2 class="lbh-heading-h2">Records created by : {{ userEmail }}</h2>
 
         <p class="lbh-body-m">Displaying {{ data | length}} record(s)</p>
 
-        {# Insert records list partial here #}
+        <table class="govuk-table lbh-table">
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Time Added</th>
+                <th scope="col" class="govuk-table__header">Name of Client</th>
+                <th scope="col" class="govuk-table__header">Date of Event</th>
+                <th scope="col" class="govuk-table__header">Type of Record</th>
+                <th scope="col" class="govuk-table__header"></th>
+                </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+                {% for item in data %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">
+                            {{item.timeAdded}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            {{item.clientName}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            {{item.eventDate}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            {{item.recordType}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            <a href="" class="js-cta-btn" id="view-record-{{item.Id}}">View</a>
+                        </td>
+                    </tr>
+                {% endfor %}
+                
+            </tbody>
+        </table>
 
     {% else %}
         <h3 class="lbh-heading-h3">No records found</h3>

--- a/views/socialcare/resident-search-results.njk
+++ b/views/socialcare/resident-search-results.njk
@@ -1,8 +1,6 @@
 {% from 'lbh-button/macro.njk' import lbhButton %}
 {% from "lbh-back-link/macro.njk" import lbhBackLink %}
 
-{# Import records list partial here #}
-
 {% extends "../layouts/base.njk" %}
 
 {% block content %}
@@ -14,9 +12,7 @@
 
     <h1 class="lbh-heading-h1">Search results</h1>
 
-    {% if helpRequestsData | length %}
-        <h2 class="lbh-heading-h2">Records matching postcode: {{postcode}}</h2>
-
+    {% if data | length %}
         <p class="lbh-body-m">Displaying {{ data | length}} record(s)</p>
 
         <div class="govuk-grid-row">
@@ -24,12 +20,44 @@
               {{ lbhButton({
                   text: "New search",
                   isSecondary: true,
-                  href: "/search"
+                  href: "/socialcare/resident-search"
               })}}
           </div>
         </div>
 
-        {# Insert records list partial here #}
+        <table class="govuk-table lbh-table">
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Date of Event</th>
+                <th scope="col" class="govuk-table__header">Name of Client</th>
+                <th scope="col" class="govuk-table__header">Email of Worker</th>
+                <th scope="col" class="govuk-table__header">Type of Record</th>
+                <th scope="col" class="govuk-table__header"></th>
+                </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+                {% for item in data %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">
+                            {{item.eventDate}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            {{item.clientName}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            {{item.workerEmail}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            {{item.recordType}}
+                        </td>
+                        <td class="govuk-table__cell">
+                            <a href="" class="js-cta-btn" id="view-record-{{item.Id}}">View</a>
+                        </td>
+                    </tr>
+                {% endfor %}
+                
+            </tbody>
+        </table>
 
     {% else %}
         <h3 class="lbh-heading-h3">No records found</h3>


### PR DESCRIPTION
Add data tables to the My Records list and Resident Search Results pages without actual field names which are to be provided once the API is ready.

Added a userNav component that displays the name of the logged-in user as well as a logout link.